### PR TITLE
on windows the erorr that returns is a path error but not 'IsNotExist'

### DIFF
--- a/ziti/enroll/enroll.go
+++ b/ziti/enroll/enroll.go
@@ -116,7 +116,7 @@ func Enroll(enFlags EnrollmentFlags) (*config.Config, error) {
 	if strings.TrimSpace(enFlags.KeyFile) != "" {
 		stat, err := os.Stat(enFlags.KeyFile)
 
-		if !os.IsNotExist(err) {
+		if stat != nil && !os.IsNotExist(err) {
 			if stat.IsDir() {
 				return nil, errors.Errorf("specified key is a directory (%s)", enFlags.KeyFile)
 			}


### PR DESCRIPTION
on windows it return an error stating the name is incorrect not that the file doesn't exist. the stat will be nil.