### PR TITLE
get fix for ziti-foundation/GH-26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/michaelquigley/pfxlog v0.0.0-20190813191113-2be43bd0dccc
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/netfoundry/ziti-foundation v0.0.0-20200121171818-46787a62eb05
+	github.com/netfoundry/ziti-foundation v0.0.0-20200128174806-bd20bcecfbe4
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/netfoundry/ziti-foundation v0.0.0-20200121171818-46787a62eb05 h1:16nNuvcH7KRF932mzekFRSF0eU7zc4AGVJFzE+4L3b4=
-github.com/netfoundry/ziti-foundation v0.0.0-20200121171818-46787a62eb05/go.mod h1:27kvN9RZk7cpt2xba6owuXktNphq5hPK62CAiKnIS10=
+github.com/netfoundry/ziti-foundation v0.0.0-20200128174806-bd20bcecfbe4 h1:sFydP1AsinlUE2PZ9cJ028152okJ/cuMs1GptknSZ8o=
+github.com/netfoundry/ziti-foundation v0.0.0-20200128174806-bd20bcecfbe4/go.mod h1:27kvN9RZk7cpt2xba6owuXktNphq5hPK62CAiKnIS10=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Update ziti-foundation to get netfoundry/ziti-foundation#26

btw, is this is "right" way to propagate fixes through the dependency chain?