### PR TITLE
fixes #41, -n flag ignored during CA auto enrollment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netfoundry/ziti-sdk-golang
 
 go 1.14
 
-//replace github.com/netfoundry/ziti-foundation => ../ziti-foundation
+// replace github.com/netfoundry/ziti-foundation => ../ziti-foundation
 
 require (
 	github.com/Jeffail/gabs v1.4.0

--- a/ziti/enroll/enroll.go
+++ b/ziti/enroll/enroll.go
@@ -390,7 +390,7 @@ func enrollCAAuto(enFlags EnrollmentFlags, cfg *config.Config, caPool *x509.Cert
 					message := respContainer.Path("error.message").Data().(string)
 					return errors.Errorf("enroll error: %s: %s: %s", resp.Status, code, message)
 				} else {
-					return errors.Errorf("enroll error: %s", resp.Status)
+					return errors.Errorf("enroll error: %s: %s", resp.Status, body)
 				}
 			}
 		}


### PR DESCRIPTION
- JSON payload was ignored as it was marked as text/plain
- updates the error outout to show the top level code/message